### PR TITLE
Zero Sized Arrays : Write UBJSONTuple::TYPE_ARRAY_END

### DIFF
--- a/include/bss-util/cUBJSON.h
+++ b/include/bss-util/cUBJSON.h
@@ -580,15 +580,19 @@ namespace bss_util {
       s.put(UBJSONTuple::TYPE_TYPE);
       s.put(type);
     }
-    s.put(UBJSONTuple::TYPE_COUNT);
-    WriteUBJSON<size_t>(size, s);
-    if(data != 0 && (type == UBJSONTuple::TYPE_CHAR || type == UBJSONTuple::TYPE_UINT8 || type == UBJSONTuple::TYPE_INT8))
-      s.write(data, size*sizeof(E)); //sizeof(E) should be 1 here but we multiply it anyway
-    else
-    {
-      for(unsigned int i = 0; i < size; ++i)
-        WriteUBJSON<E>(obj[i], s, type);
-    }
+	if (size) {
+		s.put(UBJSONTuple::TYPE_COUNT);
+		WriteUBJSON<size_t>(size, s);
+		if (data != 0 && (type == UBJSONTuple::TYPE_CHAR || type == UBJSONTuple::TYPE_UINT8 || type == UBJSONTuple::TYPE_INT8))
+			s.write(data, size * sizeof(E)); //sizeof(E) should be 1 here but we multiply it anyway
+		else
+		{
+			for (unsigned int i = 0; i < size; ++i)
+				WriteUBJSON<E>(obj[i], s, type);
+		}
+	}
+	else
+		s.put(UBJSONTuple::TYPE_ARRAY_END);
   }
 
   template<class T, int I>


### PR DESCRIPTION
Although not technically a bug, this was causing another ubjson parser to crash (I'm creating a pull request for that one too).

However, it is more compact to write the closing ']' than to write '#' 'i' '\x00'